### PR TITLE
fix: 구독 갱신 전 알림 메일을 하루에 한번 보내도록 수정

### DIFF
--- a/src/main/java/com/likelion/remini/repository/UserRepository.java
+++ b/src/main/java/com/likelion/remini/repository/UserRepository.java
@@ -3,8 +3,12 @@ package com.likelion.remini.repository;
 import com.likelion.remini.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Optional<User> findByEmail(String email);
+
+    List<User> findByExpirationDateBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/likelion/remini/service/AlarmService.java
+++ b/src/main/java/com/likelion/remini/service/AlarmService.java
@@ -10,7 +10,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 @Service
@@ -70,15 +72,19 @@ public class AlarmService {
      *
      */
     @Transactional
-    @Scheduled(cron = "0 0 * * * *") // 정각마다 실행
+    @Scheduled(cron = "0 0 9 * * *") // 매일 9시마다 실행
     public void checkAndSendAlarmsForSubscribe(){
-        LocalDateTime threeDayAfter = LocalDateTime.now().plusDays(3);
-        List<User> userList = userRepository.findUserListAfterExpiration(threeDayAfter);
+        long daysLeft = 3L;
+
+        LocalDate expirationDate = LocalDate.now().plusDays(daysLeft);
+        LocalDateTime start = LocalDateTime.of(expirationDate, LocalTime.MIN);
+        LocalDateTime end = LocalDateTime.of(expirationDate, LocalTime.MAX);
+
+        List<User> userList = userRepository.findByExpirationDateBetween(start, end);
         for(User user : userList){
             String subject = "제목 : 3일 뒤에 구독 갱신됩니다";
             String message = "내용 : 3일 뒤에 구독 갱신됩니다";
             sendAlarm(user, subject, message);
-            user.setAlarmTime(null);
             userRepository.save(user);
         }
     }


### PR DESCRIPTION
### 알림 메일을 하루에 한번 보내도록 수정
+ 매일 9시마다 `checkAndSendAlarmsForSubscribe` 메서드를 실행하도록 변경

### 현재 시간 3일 뒤 날짜의 00시부터 23:59 사이에, 구독이 만료되는 사용자를 찾도록 변경
`M월 d일 HH:mm`에 메서드가 실행되었을 때,
* 기존 코드: `(expirationDate ≤ M월 d+3일 HH:mm)`
    + 매일 실행되는 경우, 3일 전, 2일 전, 1일 전에 메일 발송
    + 만료 시간이 `HH:mm~23:59`인 경우, 3일 전에 메일 발송 X
* 현재 코드: `M월 d+3일 00:00 ≤ expirationDate ≤ M월 d+3일 23:59`